### PR TITLE
Movement Effects for Enemy & Player Bug Fix

### DIFF
--- a/Game Engine/Enemy.h
+++ b/Game Engine/Enemy.h
@@ -19,5 +19,7 @@ protected:
 	int wanderingTimer;
 	int waitingTimer;
 	short wanderDirection;
+	const float BASE_ACCELERATION = 1.2;
+	const float BASE_DECELERATION = 0.5;
 };
 

--- a/Game Engine/GameModel.h
+++ b/Game Engine/GameModel.h
@@ -77,7 +77,7 @@ private:
 	MovementEffect* rightTreadmillEffect = new MovementEffect(1, 1, 0.4, 0);
 	MovementEffect* leftTreadmillEffect = new MovementEffect(1, 1, -0.4, 0);
 	MovementEffect* upTreadmillEffect = new MovementEffect(1, 1, 0, -0.4);
-	MovementEffect* iceEffect = new MovementEffect(0.2, 1.9, 0, 0);
+	MovementEffect* iceEffect = new MovementEffect(0.9 , 1.9, 0, 0);
 	MovementEffect* mudEffect = new MovementEffect(0.4, 1, 0, 0, -1);
 };
 

--- a/Game Engine/Player.cpp
+++ b/Game Engine/Player.cpp
@@ -23,8 +23,8 @@ Player & Player::getPointerToThis()
 
 void Player::determineMovement(double playerPosX, double playerPosY, std::vector<MovementEffect*> effects)
 {
-	float acceleration = 1;
-	float deceleration = 0.5;
+	float acceleration = BASE_ACCELERATION;
+	float deceleration = BASE_DECELERATION;
 	float maxVelChangeTotal = 0;
 
 	if (effects.size() != 0)
@@ -48,7 +48,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 		if (horizontalMovementKeyPress == 0)
 		{
 			setVelocityX(velocityX * deceleration);
-			if (velocityX < 0.1)
+			if (velocityX < 0.1 && velocityX > -0.1)
 			{
 				velocityX = 0;
 			}
@@ -59,7 +59,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 			{
 				velocityX = 0.5;
 			}
-			setVelocityX(velocityX * BASE_ACCELERATION);
+			setVelocityX(velocityX * acceleration);
 			if (velocityX > max)
 			{
 				velocityX = max;
@@ -72,7 +72,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 			{
 				velocityX = -0.5;
 			}
-			setVelocityX(velocityX * BASE_ACCELERATION);
+			setVelocityX(velocityX * acceleration);
 			if (velocityX < max * -1)
 			{
 				velocityX = max * -1;
@@ -82,7 +82,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 		if (verticalMovementKeyPress == 0)
 		{
 			setVelocityY(velocityY * deceleration);
-			if (velocityY < 0.1)
+			if (velocityY < 0.1 && velocityY > -0.1)
 			{
 				velocityY = 0;
 			}
@@ -93,7 +93,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 			{
 				velocityY = 0.5;
 			}
-			setVelocityY(velocityY * BASE_ACCELERATION);
+			setVelocityY(velocityY * acceleration);
 			if (velocityY > max)
 			{
 				velocityY = max;
@@ -106,7 +106,7 @@ void Player::determineMovement(double playerPosX, double playerPosY, std::vector
 			{
 				velocityY = -0.5;
 			}
-			setVelocityY(velocityY * BASE_ACCELERATION);
+			setVelocityY(velocityY * acceleration);
 			if (velocityY < max * -1)
 			{
 				velocityY = max * -1;

--- a/Game Engine/Player.h
+++ b/Game Engine/Player.h
@@ -25,4 +25,5 @@ private:
 	short verticalMovementKeyPress = 0; // -1 for up, 0 for neither key pressed, 1 for down, should only be one of these three values
 	const float MAX_VELOCITY = 2;
 	const float BASE_ACCELERATION = 1.2;
+	const float BASE_DECELERATION = 0.5;
 };


### PR DESCRIPTION
- Altered the Enemy class's determineMovement to use deceleration/acceleration and to be affected by MovementEffect(s).
- Fixed some forgotten variable changes involving acceleration/BASE_ACCELERATION for Player (acceleration changes weren't being applied for up/left movement)
- Also noticed and fixed a bug with normal deceleration for up/left movement that I likely hadn't noticed all this time.